### PR TITLE
[WIP] [ENH] Reimplement benchmarking with `kotsu`

### DIFF
--- a/sktime/benchmarking/__init__.py
+++ b/sktime/benchmarking/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Implements running validations on estimators storing results for benchmarking."""

--- a/sktime/benchmarking/__init__.py
+++ b/sktime/benchmarking/__init__.py
@@ -1,2 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implements running validations on estimators storing results for benchmarking."""
+from kotsu import registration
+
+estimator_registry = registration.ModelRegistry()
+validation_registry = registration.ValidationRegistry()

--- a/sktime/benchmarking/__init__.py
+++ b/sktime/benchmarking/__init__.py
@@ -4,3 +4,6 @@ from kotsu import registration
 
 estimator_registry = registration.ModelRegistry()
 validation_registry = registration.ValidationRegistry()
+
+from sktime.benchmarking import estimators  # noqa
+from sktime.benchmarking import validations  # noqa

--- a/sktime/benchmarking/estimators.py
+++ b/sktime/benchmarking/estimators.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""Register estimators to compete in benchmarking."""
+
+from sktime.benchmarking import estimator_registry
+from sktime.forecasting.ets import AutoETS
+from sktime.forecasting.naive import NaiveForecaster
+
+estimator_registry.register(
+    id="Naive-v1",
+    entry_point=NaiveForecaster,
+    kwargs={"strategy": "mean", "sp": 12},
+)
+
+estimator_registry.register(
+    id="ETS-v1",
+    entry_point=AutoETS,
+    kwargs={"auto": "True", "n_jobs": -1, "sp": 12},
+)

--- a/sktime/benchmarking/run.ipynb
+++ b/sktime/benchmarking/run.ipynb
@@ -1,0 +1,101 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b99fe5e9",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "145d5a96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from kotsu import run\n",
+    "\n",
+    "from sktime.benchmarking import estimator_registry, validation_registry"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a84db36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validation_registry.all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "023bef3d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "estimator_registry.all()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "637b1a67",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run.run(estimator_registry, validation_registry, \"./results.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85c1d549",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv(\"./results.csv\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea465ffa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/sktime/benchmarking/tests/test_validations.py
+++ b/sktime/benchmarking/tests/test_validations.py
@@ -1,0 +1,105 @@
+# -*- coding: utf-8 -*-
+"""Tests for benchmarking validation functions."""
+
+import numpy as np
+import pandas as pd
+
+from sktime.benchmarking import validations
+from sktime.forecasting.base import BaseForecaster
+from sktime.forecasting.model_selection._split import BaseSplitter
+from sktime.performance_metrics.forecasting import MeanAbsoluteError, MeanSquaredError
+
+
+class FakeSplitter(BaseSplitter):
+    """A fake splitter that returns the whole series (for train and test) each split."""
+
+    def __init__(self, n_splits, fh):
+        self.n_splits = n_splits
+        self.fh = fh
+        super().__init__()
+
+    def _split(self, y):
+        for _ in range(self.n_splits):
+            yield y, y
+
+
+class LastValueEstimator(BaseForecaster):
+    """An estimator that repeats the last value of the train data as the forecast."""
+
+    _tags = {
+        "requires-fh-in-fit": False,
+        # "scitype:y": "univariate",
+    }
+
+    def __init__(self):
+        self.last_value = None
+        super().__init__()
+
+    def _fit(self, y, X=None, fh=None):
+        self.last_value = y.iloc[-1]
+
+    def _predict(self, fh=None, X=None):
+        return pd.Series(np.full(fill_value=self.last_value, shape=len(fh)))
+
+
+def test_forecasting_validation():
+    """Test that output dict of the validation function is as expected.
+
+    We want to avoid testing sktime functionality outside of the validator, so we use
+    fake splitters and estimators and just check the results dict.
+    """
+
+    def dataset_loader():
+        return pd.Series([1, 2, 3, 4])
+
+    # Fake splitter will give the whole series as train and test data for each split
+    cv_splitter = FakeSplitter(n_splits=2, fh=4)
+    # Our estimator predicts the final value of the train data, so all 4s for each split
+    estimator = LastValueEstimator()
+
+    results = validations.forecasting_validation(
+        dataset_loader=dataset_loader,
+        cv_splitter=cv_splitter,
+        scorers=[MeanAbsoluteError(), MeanSquaredError()],
+        estimator=estimator,
+    )
+
+    # Just check that we have the results keys that we expect
+    assert len(results) == 8
+    assert results["MeanAbsoluteError_fold_0_test"] == 1.5
+    assert results["MeanAbsoluteError_fold_1_test"] == 1.5
+    assert results["MeanSquaredError_fold_0_test"] == 3.5
+    assert results["MeanSquaredError_fold_1_test"] == 3.5
+    assert results["MeanAbsoluteError_mean"] == 1.5
+    assert results["MeanSquaredError_mean"] == 3.5
+    # All the splits are the same, so the std will be 0
+    assert results["MeanAbsoluteError_std"] == 0
+    assert results["MeanSquaredError_std"] == 0
+
+
+def test_forecasting_validation_deterministic():
+    """Test validation gives deterministic results using a deterministic splitter."""
+
+    def dataset_loader():
+        return pd.Series([1, 2, 3, 4])
+
+    # Fake splitter will give the whole series as train and test data for each split
+    # And it's clearly deterministic
+    cv_splitter = FakeSplitter(n_splits=2, fh=4)
+    # Our estimator predicts the final value of the train data, so all 4s for each split
+    estimator = LastValueEstimator()
+
+    results = validations.forecasting_validation(
+        dataset_loader=dataset_loader,
+        cv_splitter=cv_splitter,
+        scorers=[MeanAbsoluteError(), MeanSquaredError()],
+        estimator=estimator,
+    )
+    repeated_results = validations.forecasting_validation(
+        dataset_loader=dataset_loader,
+        cv_splitter=cv_splitter,
+        scorers=[MeanAbsoluteError(), MeanSquaredError()],
+        estimator=estimator,
+    )
+
+    assert results == repeated_results

--- a/sktime/benchmarking/validations.py
+++ b/sktime/benchmarking/validations.py
@@ -3,10 +3,14 @@
 import functools
 from typing import Callable, Dict, List, Union
 
+from sktime.benchmarking import validation_registry
+from sktime.datasets import load_airline
 from sktime.forecasting.base import BaseForecaster
 from sktime.forecasting.model_evaluation import evaluate
+from sktime.forecasting.model_selection import ExpandingWindowSplitter
 from sktime.forecasting.model_selection._split import BaseSplitter
 from sktime.performance_metrics.base import BaseMetric
+from sktime.performance_metrics.forecasting import MeanSquaredPercentageError
 
 
 def forecasting_validation(
@@ -40,4 +44,20 @@ def factory_forecasting_validation(
         dataset_loader,
         cv_splitter,
         scorers,
+    )
+
+
+for dataset_loader in [load_airline]:
+    validation_registry.register(
+        id=f"forecasting_[dataset={dataset_loader.__name__}]_ExpandingWindow-v1",
+        entry_point=factory_forecasting_validation,
+        kwargs={
+            "dataset_loader": dataset_loader,
+            "cv_splitter": ExpandingWindowSplitter(
+                initial_window=24,
+                step_length=12,
+                fh=12,
+            ),
+            "scorers": [MeanSquaredPercentageError()],
+        },
     )

--- a/sktime/benchmarking/validations.py
+++ b/sktime/benchmarking/validations.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+"""Implement and register validations, which compute benchmark results."""
+from typing import Callable, Dict, List, Union
+
+from sktime.forecasting.base import BaseForecaster
+from sktime.forecasting.model_evaluation import evaluate
+from sktime.forecasting.model_selection._split import BaseSplitter
+from sktime.performance_metrics.base import BaseMetric
+
+
+def forecasting_validation(
+    dataset_loader: Callable,
+    cv_splitter: BaseSplitter,
+    scorers: List[BaseMetric],
+    estimator: BaseForecaster,
+    **kwargs,
+) -> Dict[str, Union[float, str]]:
+    """Run validation for forecasting benchmarks."""
+    y = dataset_loader()
+    results = {}
+    for scorer in scorers:
+        scorer_name = scorer.name
+        scores_df = evaluate(forecaster=estimator, y=y, cv=cv_splitter, scoring=scorer)
+        for ix, row in scores_df.iterrows():
+            results[f"{scorer_name}_fold_{ix}_test"] = row[f"test_{scorer_name}"]
+        results[f"{scorer_name}_mean"] = scores_df[f"test_{scorer_name}"].mean()
+        results[f"{scorer_name}_std"] = scores_df[f"test_{scorer_name}"].std()
+    return results

--- a/sktime/benchmarking/validations.py
+++ b/sktime/benchmarking/validations.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Implement and register validations, which compute benchmark results."""
+import functools
 from typing import Callable, Dict, List, Union
 
 from sktime.forecasting.base import BaseForecaster
@@ -26,3 +27,17 @@ def forecasting_validation(
         results[f"{scorer_name}_mean"] = scores_df[f"test_{scorer_name}"].mean()
         results[f"{scorer_name}_std"] = scores_df[f"test_{scorer_name}"].std()
     return results
+
+
+def factory_forecasting_validation(
+    dataset_loader: Callable,
+    cv_splitter: BaseSplitter,
+    scorers: List[BaseMetric],
+) -> Callable:
+    """Build forecasting validation func which just takes an estimator."""
+    return functools.partial(
+        forecasting_validation,
+        dataset_loader,
+        cv_splitter,
+        scorers,
+    )


### PR DESCRIPTION
(Note, the first 3 sections of the PR message Dan added for us, the rest are from sktime's PR message template.)
 
#### Usage instructions:
- See the reference issues below for getting context
- See https://www.sktime.org/en/latest/developer_guide.html#developer-guide to set up sktime dev env (I used pyenv, made a venv, `pip install -e .[dev]`, `pip install pre-commit`, `pre-commit install`).
- Dependencies to install specific for this PR: `autoreload`, `kotsu`, `jupyter`, `typing_extensions`
- Try running the `sktime/benchmarking/run.ipynb`

#### To do / decide now : 
- [x] @alex-hh @ali-tny review and share thoughts on implementation etc.
- [x] Dan was getting a break from `kotsu` with `typing_extension module not found` error as we import `Literal` from that in `kotsu` - I "fixed" it by `pip install typing_extensions` in my sktime venv. I think this might be an issue in `kotsu` as we didn't include `typing_extensions` in its requirements?! Weird that it doesn't break in `kotsu` CI. 
- [x] Should we use a separate file for where define the main validation funcs and another file for registering them?
- [x] What should be unit tested, and what should be considered like "benchmarking infra"?
    - [x] Write those unit tests. 

#### To discuss with sktime team Tuesday 28th: 
- [ ] What [type of dependency](https://www.sktime.org/en/latest/developer_guide/dependencies.html#types-of-dependencies) will `kotsu` be? (Dan thinks `soft`.) 
- [ ] What interface wanted for running the benchmarking? A python script? A jupyter notebook? 
- [ ] Register estimators in estimator modules or in benchmarking module? (Dan thinks within benchmarking.)
- [ ] Saving copies of the folds? Saving estimator predictions? Or just save end scores. 
- [ ] Do we want to implement visualisations/explorations/further analysis? In benchmarking there's some analysis (e.g. t-tests etc.) modules. Or just store the base benchmark results and let people do analysis on those as they see fit?
- [ ] We're trying to write as little code as pos and rely on sktime functionality as possible. `evaluate` only takes a single `scorer` - we would want to avoid running most training and pred for every scoring metrics. 

<!--
Thanks for contributing a pull request! Please ensure you have taken a look
at our contribution guide: https://github.com/alan-turing-institute/sktime/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.

Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
See discussion: https://github.com/alan-turing-institute/sktime/issues/2777
See discussion: https://github.com/alan-turing-institute/sktime/issues/2804
See spike: https://github.com/alan-turing-institute/sktime/pull/2805


#### What does this implement/fix? Explain your changes.
<!--
A clear and concise description of what you have implemented.
-->

Implement benchmarking using `kotsu`. 
- Instantiation of a `validation_registry` and `estimator_registry` in `benchmarking`'s `init`
- A `validations.py` module which defines and registers validation runs.
- An 'estimators.py' module which imports and registers estimators + their configs (i.e. param specifications)
- A `run.py` module and/or a `run.ipynb` which runs the registry of estimators  

Likely we will eventually want to have separate registries corresponding to different types of predictions (classification, regression, etc.), for now this just implements for regression (point prediction). 

#### Does your contribution introduce a new dependency? If yes, which one?

<!--
If your contribution does add a new hard dependency, we may suggest to initially develop your contribution in a separate companion package in https://github.com/sktime/ to keep external dependencies of the core sktime package to a minimum.
-->


#### What should a reviewer concentrate their feedback on?

<!-- This section is particularly useful if you have a pull request that is still in development. You can guide the reviews to focus on the parts that are ready for their comments. We suggest using bullets (indicated by * or -) and filled checkboxes [x] here -->

The understandability, flexibility, extendability, and maintainability, of this benchmarking system implementation. 

#### Any other comments?
<!--
Please be aware that we are a loose team of volunteers so patience is necessary; assistance handling other issues is very welcome. We value all user contributions, no matter how minor they are. If we are slow to review, either the pull request needs some benchmarking, tinkering, convincing, etc. or more likely the reviewers are simply busy. In either case, we ask for your understanding during the review process.
-->

#### PR checklist
<!--
Please go through the checklist below. Please feel free to remove points if they are not applicable.
-->

##### For all contributions
- [ ] I've added myself to the [list of contributors](https://github.com/alan-turing-institute/sktime/blob/main/.all-contributorsrc).
- [ ] Optionally, I've updated sktime's [CODEOWNERS](https://github.com/alan-turing-institute/sktime/blob/main/CODEOWNERS) to receive notifications about future changes to these files.
- [ ] I've added unit tests and made sure they pass locally.
- [ ] The PR title starts with either [ENH], [MNT], [DOC], or [BUG] indicating whether the PR topic is related to enhancement, maintenance, documentation, or bug.

<!--
Thanks for contributing!
-->
